### PR TITLE
refactor: Makefileのテストコマンドを改修

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,7 +32,7 @@ jobs:
         run: mint run xcodegen generate
 
       - name: Build for Testing via Makefile
-        run: make build-test # SIMULATOR_UDID is now handled by Makefile's select-simulator
+        run: make build-test
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
@@ -78,7 +78,7 @@ jobs:
 
       - name: Run Unit Tests via Makefile
         id: unit_tests
-        run: make unit-test # SIMULATOR_UDID is now handled by Makefile's select-simulator
+        run: make unit-test-without-building
 
       - name: Upload Unit Test Results
         if: always()
@@ -124,7 +124,7 @@ jobs:
 
       - name: Run UI Tests via Makefile
         id: ui_tests
-        run: make ui-test # SIMULATOR_UDID is now handled by Makefile's select-simulator
+        run: make ui-test-without-building
 
       - name: Upload UI Test Results
         if: always()

--- a/Makefile
+++ b/Makefile
@@ -4,25 +4,27 @@ SHELL := /bin/bash
 #
 # [ユーザ向けコマンド]
 # --- Xcodeの操作 ---
-#   make boot                - ローカルシミュレータ（iPhone 16 Pro）を起動
-#   make run-debug           - デバッグビルドを作成し、ローカルシミュレータにインストール、起動
-#   make run-release         - リリースビルドを作成し、ローカルシミュレータにインストール、起動
-#   make clean-proj          - Xcodeプロジェクトのビルドフォルダをクリーン
-#   make resolve-pkg         - SwiftPMキャッシュ・依存関係・ビルドをリセット
-#   make open-proj           - Xcodeでプロジェクトを開く
-#   make test-packages       - CatBoard内の全てのローカルパッケージテストを実行
+#   make boot                      - ローカルシミュレータ（iPhone 16 Pro）を起動
+#   make run-debug                 - デバッグビルドを作成し、ローカルシミュレータにインストール、起動
+#   make run-release               - リリースビルドを作成し、ローカルシミュレータにインストール、起動
+#   make clean-proj                - Xcodeプロジェクトのビルドフォルダをクリーン
+#   make resolve-pkg               - SwiftPMキャッシュ・依存関係・ビルドをリセット
+#   make open-proj                 - Xcodeでプロジェクトを開く
+#   make test-packages             - CatBoard内の全てのローカルパッケージテストを実行
 #
-# --- ビルド関連 ---
-#   make build-test          - テスト用ビルド（テスト実行前に必須）
-#   make archive             - リリース用のアーカイブを作成
+# --- ビルド ---
+#   make build-test                - テスト用ビルド（テスト実行前に必須）
+#   make archive                   - リリース用のアーカイブを作成
 #
-# --- テスト関連 ---
-#   make unit-test           - ユニットテストを実行
-#   make ui-test             - UIテストを実行
-#   make test-all            - 全テストを実行
+# --- テスト ---
+#   make unit-test                  - ユニットテストをビルドして実行
+#   make ui-test                    - UIテストをビルドして実行
+#   make test-all                   - 全テストをビルドして実行
+#   make unit-test-without-building  - ユニットテストを実行（ビルドなし）
+#   make ui-test-without-building    - UIテストを実行（ビルドなし）
 #
 # [内部ワークフロー用コマンド]
-#   make find-test-artifacts - テストの成果物探索
+#   make find-test-artifacts        - テストの成果物探索
 #
 # === Configuration ===
 OUTPUT_DIR := build
@@ -208,6 +210,27 @@ unit-test:
 	@echo "Using Simulator UDID: $(SIMULATOR_RAW)"
 	@echo "🧪 Running Unit Tests..."
 	@rm -rf $(UNIT_TEST_RESULTS)
+	@set -o pipefail && xcodebuild test \
+		-project $(PROJECT_FILE) \
+		-scheme $(UNIT_TEST_SCHEME) \
+		-destination "platform=iOS Simulator,id=$(word 1,$(subst |, ,$(SIMULATOR_RAW)))" \
+		-derivedDataPath $(DERIVED_DATA_PATH) \
+		-enableCodeCoverage NO \
+		-resultBundlePath $(UNIT_TEST_RESULTS) \
+		CODE_SIGNING_ALLOWED=NO \
+		| xcbeautify
+	@if [ ! -d "$(UNIT_TEST_RESULTS)" ]; then \
+		echo "❌ Error: Unit test result bundle not found"; \
+		exit 1; \
+	fi
+	@echo "✅ Unit tests completed. Results: $(UNIT_TEST_RESULTS)"
+
+.PHONY: unit-test-without-building
+unit-test-without-building:
+	$(eval SIMULATOR_RAW := $(call select-simulator,$(UNIT_TEST_SCHEME)))
+	@echo "Using Simulator UDID: $(SIMULATOR_RAW)"
+	@echo "🧪 Running Unit Tests..."
+	@rm -rf $(UNIT_TEST_RESULTS)
 	@set -o pipefail && xcodebuild test-without-building \
 		-project $(PROJECT_FILE) \
 		-scheme $(UNIT_TEST_SCHEME) \
@@ -230,6 +253,27 @@ ui-test:
 	@echo "Using Simulator UDID: $(SIMULATOR_RAW)"
 	@echo "🧪 Running UI Tests..."
 	@rm -rf $(UI_TEST_RESULTS)
+	@set -o pipefail && xcodebuild test \
+		-project $(PROJECT_FILE) \
+		-scheme $(UI_TEST_SCHEME) \
+		-destination "platform=iOS Simulator,id=$(word 1,$(subst |, ,$(SIMULATOR_RAW)))" \
+		-derivedDataPath $(DERIVED_DATA_PATH) \
+		-enableCodeCoverage NO \
+		-resultBundlePath $(UI_TEST_RESULTS) \
+		CODE_SIGNING_ALLOWED=NO \
+		| xcbeautify
+	@if [ ! -d "$(UI_TEST_RESULTS)" ]; then \
+		echo "❌ Error: UI test result bundle not found"; \
+		exit 1; \
+	fi
+	@echo "✅ UI tests completed. Results: $(UI_TEST_RESULTS)"
+
+.PHONY: ui-test-without-building
+ui-test-without-building:
+	$(eval SIMULATOR_RAW := $(call select-simulator,$(UI_TEST_SCHEME)))
+	@echo "Using Simulator UDID: $(SIMULATOR_RAW)"
+	@echo "🧪 Running UI Tests..."
+	@rm -rf $(UI_TEST_RESULTS)
 	@set -o pipefail && xcodebuild test-without-building \
 		-project $(PROJECT_FILE) \
 		-scheme $(UI_TEST_SCHEME) \
@@ -247,7 +291,7 @@ ui-test:
 
 # === All tests ===
 .PHONY: test-all
-test-all: find-test-artifacts unit-test ui-test
+test-all: build-test unit-test-without-building ui-test-without-building
 	@echo "✅ All tests completed."
 
 # === Find existing artifacts ===


### PR DESCRIPTION
ローカル開発の利便性向上のため、Makefileのテスト関連コマンドを改修しました。

変更点：
- 既存の`make unit-test`と`make ui-test`を、それぞれ`make unit-test-without-building`と`make ui-test-without-building`にリネームしました。
- CIでこれらのコマンドを呼び出している`.github/workflows/run-tests.yml`を修正しました。
- ビルドとテストを一度に実行する新しい`make unit-test`と`make ui-test`を`xcodebuild test`を使用して作成しました。
- `make test-all`がビルドを1回だけ実行するように依存関係を修正しました。
- Makefileのコメントを最新化し、コマンドの分類をより正確にしました。
- CIワークフローファイルから不要なコメントを削除しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ビルドなしでユニットテストおよびUIテストを実行する新しいコマンドが追加されました。

* **改善**
  * テストコマンドやビルドコマンドの説明コメントが整理・統一され、見やすくなりました。
  * テスト全体の実行フローが改善され、ビルド後にテストのみを効率的に実行できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->