### PR TITLE
docs: Update directory structure in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,12 @@ Since the screening process involves machine learning, verification on a real de
 .
 ├── .github/
 ├── CatBoardApp/
-├── CatAPIClient/
-├── CatImageLoader/
-├── CatImagePrefetcher/
-├── CatImageScreener/
-├── CatImageURLRepository/
+├── Packages/
+│   ├── CatAPIClient/
+│   ├── CatImageLoader/
+│   ├── CatImagePrefetcher/
+│   ├── CatImageScreener/
+│   └── CatImageURLRepository/
 ├── CatBoardTests/
 ├── CatBoardUITests/
 ├── fastlane/


### PR DESCRIPTION
The directory structure in the README.md file was outdated. The local Swift packages were moved to a `Packages` directory, but the README still showed them at the root level.

This commit updates the "Directory Structure" section to accurately reflect the current project layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * READMEのディレクトリ構成セクションを更新し、プロジェクトモジュールが新たに「Packages」サブディレクトリにまとめられたことを反映しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->